### PR TITLE
Skip empty files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/
 dist/
 *.egg-info/
 .eggs/
+pip-wheel-metadata/
 .mypy_cache/
 .pytest_cache/
 __pycache__/

--- a/apache_license_check.py
+++ b/apache_license_check.py
@@ -49,6 +49,11 @@ def python_files(path, include_hidden, excludes):
         yield path
 
 
+def is_empty(path):
+    content = path.read_text()
+    return len(content.strip()) == 0
+
+
 def read_header_lines(path):
 
     header_lines = []
@@ -109,6 +114,12 @@ def cli():
         help="also check hidden files and directories",
     )
     parser.add_argument(
+        "--include-empty",
+        action="store_true",
+        help="require empty files (e.g. empty __init__.py), which are skipped "
+        + "by default",
+    )
+    parser.add_argument(
         "--exclude",
         nargs="+",
         type=Path,
@@ -131,16 +142,21 @@ def cli():
 
             output = str(file)
 
-            header_lines = read_header_lines(file)
+            if not args.include_empty and is_empty(file):
+                output += " " + colored("SKIPPED", "yellow")
+            else:
+                header_lines = read_header_lines(file)
 
-            if args.copyright is not None:
-                has_copyright = check_copyright(header_lines, args.copyright)
-                output += " Copyright: " + format_success(has_copyright)
-                success = success and has_copyright
+                if args.copyright is not None:
+                    has_copyright = check_copyright(
+                        header_lines, args.copyright
+                    )
+                    output += " Copyright: " + format_success(has_copyright)
+                    success = success and has_copyright
 
-            has_license = check_license(header_lines)
-            output += " License: " + format_success(has_license)
-            success = success and has_license
+                has_license = check_license(header_lines)
+                output += " License: " + format_success(has_license)
+                success = success and has_license
 
             print(output)
 

--- a/apache_license_check.py
+++ b/apache_license_check.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Faculty Science Limited
+# Copyright 2019-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apache_license_check.py
+++ b/apache_license_check.py
@@ -143,7 +143,7 @@ def cli():
             output = str(file)
 
             if not args.include_empty and is_empty(file):
-                output += " " + colored("SKIPPED", "yellow")
+                output += " " + colored("EMPTY", "yellow")
             else:
                 header_lines = read_header_lines(file)
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Faculty Science Limited
+# Copyright 2019-2020 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Requiring empty source files to have a copyright and license statement is a bit silly, so this change disables it by default. Checks on these files can be kept with the `--include-empty` flag.